### PR TITLE
ci: correct the docker version for Rust 2024

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - rust: 1.79.0 # MSRV
+                    - rust: 1.85.0 # MSRV
                       label: msrv
                       logo: ubuntu
                       os: ubuntu

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 description = ""
 repository = "https://github.com/${gh_user}/${project-name}"
 license = "MIT OR Apache-2.0"
-rust-version = "1.79.0"
+rust-version = "1.85.0"
 
 [lib]
 name = "variant_forge_lib"

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 #    It copies the binary from the builder image and sets it as the entry point of the container
 
 # Use the official Rust image as the builder image
-# Use the 1.75 version of the Rust image since it's the MSRV (Minimum Supported Rust Version) for the aaprop project
+# Use the 1.85 version of the Rust image since it's the MSRV (Minimum Supported Rust Version) for the aaprop project
 FROM rust:1.85.0 AS builder
 
 # Set the working directory in the builder image to /usr/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 
 # Use the official Rust image as the builder image
 # Use the 1.75 version of the Rust image since it's the MSRV (Minimum Supported Rust Version) for the aaprop project
-FROM rust:1.79.0 AS builder
+FROM rust:1.85.0 AS builder
 
 # Set the working directory in the builder image to /usr/src
 WORKDIR /usr/src

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ An application for calculating distances between proteins as a result of amino-a
 | Stable|![Ubuntu x Stable Rust](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/AliSajid/2feb2c401cf1cd81ab15e0978f2835d0/raw/ubuntu-stable.json)|
 | Beta|![Ubuntu x Beta Rust](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/AliSajid/2feb2c401cf1cd81ab15e0978f2835d0/raw/ubuntu-beta.json)|
 | Nightly|![Ubuntu x Nightly Rust](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/AliSajid/2feb2c401cf1cd81ab15e0978f2835d0/raw/ubuntu-nightly.json)|
-| MSRV (1.79.0)|![Ubuntu x MSRV Rust](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/AliSajid/2feb2c401cf1cd81ab15e0978f2835d0/raw/ubuntu-msrv.json)|
+| MSRV (1.85.0)|![Ubuntu x MSRV Rust](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/AliSajid/2feb2c401cf1cd81ab15e0978f2835d0/raw/ubuntu-msrv.json)|
 
 
 ## Current Status


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 Ali Sajid Imami

SPDX-License-Identifier: Apache-2.0
SPDX-License-Identifier: MIT
-->

# Description

Updated the Minimum Supported Rust Version (MSRV) from 1.79.0 to 1.85.0 across all project configuration files. This includes updates to the CI workflow, Cargo.toml metadata, Dockerfile base image, and README documentation.

Fixes # (issue)

## Change Type

Please delete options that are not relevant.

- [x] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a capability)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] This change requires a documentation update

# How Was This Tested?

- [x] Verified CI workflow runs successfully with the new Rust version
- [x] Confirmed build process works with Rust 1.85.0

**Test Configuration**:
* Toolchain Version: 1.85.0
* Toolchain Channel: stable
* Operating System: Ubuntu
* Any other relevant details: Updated CI configuration to test against the new MSRV

# Checklist:

- [x] Code follows the project's style guidelines
- [x] Code has undergone self-review
- [x] Documentation updated to reflect changes
- [x] Changes do not generate new warnings
- [x] All unit tests pass locally with these changes